### PR TITLE
Add Package-Requires header for ELPA installations

### DIFF
--- a/eval-sexp-fu.el
+++ b/eval-sexp-fu.el
@@ -3,6 +3,7 @@
 ;; Copyright (C) 2009-2013 Takeshi Banse <takebi@laafc.net>
 ;; Author: Takeshi Banse <takebi@laafc.net>
 ;; Keywords: lisp, highlight, convenience
+;; Package-Requires: ((highlight "0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
When installing this package from Melpa (or any other ELPA repository in which it might be found) then `highlight` should also be installed. This commit adds the corresponding `Package-Requires` header. 
