### PR TITLE
rename missing multiple-value-bind to cl-multiple-value-bind

### DIFF
--- a/eval-sexp-fu.el
+++ b/eval-sexp-fu.el
@@ -279,7 +279,7 @@ See also `eval-sexp-fu-flash'."
   (declare (indent 1))
   `(defadvice ,command (around eval-sexp-fu-flash-region activate)
      (if eval-sexp-fu-flash-mode
-         (multiple-value-bind (bounds hi unhi eflash) ,form
+         (cl-multiple-value-bind (bounds hi unhi eflash) ,form
            (if bounds
                (esf-flash-doit (esf-konstantly ad-do-it) hi unhi eflash)
              ad-do-it))


### PR DESCRIPTION
without this change I get

```
Warning (bytecomp): reference to free variable ‘hi’
Warning (bytecomp): reference to free variable ‘unhi’
Warning (bytecomp): reference to free variable ‘eflash’
Warning (bytecomp): reference to free variable ‘bounds’
Warning (bytecomp): reference to free variable ‘hi’
Warning (bytecomp): reference to free variable ‘unhi’
Warning (bytecomp): reference to free variable ‘eflash’
Warning (bytecomp): reference to free variable ‘bounds’
```
as multiple-value-bind doesn't exist in Emacs 25.3+ and these variables don't get bounded.